### PR TITLE
Move babel-polyfill back to devDepency & Add core-js and regenerator-runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,16 @@
 	},
 	"dependencies": {
 		"ajv": "~6.3.0",
-		"babel-polyfill": "^6.26.0",
+		"core-js": "^2.5.6",
 		"lodash": "^4.17.10",
-		"pug": "^2.0.3"
+		"pug": "^2.0.3",
+		"regenerator-runtime": "^0.11.1"
 	},
 	"devDependencies": {
 		"babel-cli": "^6.26.0",
 		"babel-core": "^6.26.0",
 		"babel-plugin-transform-object-rest-spread": "^6.26.0",
+		"babel-polyfill": "^6.26.0",
 		"babel-preset-env": "^1.6.1",
 		"eslint": "^4.19.1",
 		"eslint-config-aftership": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,6 +1344,10 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
+core-js@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -4166,7 +4170,7 @@ regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
`babel-preset-env` will use `babel-polyfill` to require `core-js` and `regenerator-runtime` in the built files. But `npm install` won't flatten these 2 dependencies in `node_modules` under api's root or `swagger-ajv`'s root, yielding them unable to be found.