### PR TITLE
fix(ajv formats): add back ajv formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	"dependencies": {
 		"ajv": "^8.8.2",
 		"ajv-errors": "^3.0.0",
+		"ajv-formats": "^2.1.1",
 		"js-yaml": "^3.13.1",
 		"lodash": "^4.17.21",
 		"pug": "^3.0.2"

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Ajv = require('ajv');
+const ajvFormats = require('ajv-formats');
 const {omit} = require('lodash');
 
 const errorParser = require('./error_parser');
@@ -20,6 +21,7 @@ module.exports = ({
 		...ajvOptions,
 	});
 
+	ajvFormats(ajv);
 	require('ajv-errors')(ajv, ajvErrorsOptions);
 
 	// See https://github.com/eslint/eslint/issues/12117

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,6 +1339,13 @@ ajv-errors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-3.0.0.tgz#e54f299f3a3d30fe144161e5f0d8d51196c527bc"
   integrity sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1347,6 +1354,16 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
 ajv@^8.8.2:


### PR DESCRIPTION
the ajv formats are now in a separate package ajv-formats.

https://ajv.js.org/packages/ajv-formats.html

https://github.com/ajv-validator/ajv/releases/tag/v7.0.0